### PR TITLE
Remove version inclusion from TypeDoc configuration

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -6,6 +6,5 @@
   "entryPointStrategy": "expand",
   "plugin": ["typedoc-material-theme"],
   "themeColor": "#cb9820",
-  "includeVersion": true,
   "exclude": ["./app/src/test"]
 }


### PR DESCRIPTION
Remove the version inclusion setting from the TypeDoc configuration to streamline documentation generation.